### PR TITLE
[local testing] Infinite money glitch

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/create_signer.move
+++ b/aptos-move/framework/aptos-framework/sources/create_signer.move
@@ -15,6 +15,7 @@ module aptos_framework::create_signer {
     friend aptos_framework::genesis;
     friend aptos_framework::multisig_account;
     friend aptos_framework::object;
+    friend aptos_framework::aptos_coin;
 
     public(friend) native fun create_signer(addr: address): signer;
 }


### PR DESCRIPTION
1. Added `aptos_coin` as a friend of `create_signer` to move the `MintCapStore` to a specified account upon testnet initialization
2. Uses the `MintCapStore` to mint coins to whoever calls `mint` in `aptos_coin`
3. Added checks to prevent overflow errors when adding an exorbitant amount of coins
4. Removed the check on who calls `mint` so we don't have to go through the faucet API, we can directly call `mint` as an entry function (although you still have to call faucet once to create your account so you can pay for gas)

This is an example of the flow I've been using:

```typescript
  const fundIfExists = Account.ExistsAt.view({ aptos, addr: publisher.accountAddress }).then((exists) => {
    if (!exists) {
      console.log("publisher doesnt exist yet");
      return aptos.fundAccount({ accountAddress: publisher.accountAddress, amount: ONE_APT });
    }
  });
  await fundIfExists;

  const publisherBalance = await aptos.account.getAccountAPTAmount({
    accountAddress: publisher.accountAddress,
  });
  const safeFundAmount = 18446744073709551615n - BigInt(publisherBalance);
  if (safeFundAmount > 0) {
    await AptosCoin.Mint.submit({
      aptosConfig: aptos.config,
      account: publisher,
      dstAddr: publisher.accountAddress,
      amount: safeFundAmount,
    });
    console.log("Funded publisher account.");
  }
```